### PR TITLE
NetCore 3.1 support

### DIFF
--- a/src/Logging/FormattedLogValues.cs
+++ b/src/Logging/FormattedLogValues.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace RedBear.LogDNA.Extensions.Logging
+{
+    /// <summary>
+    /// LogValues to enable formatting options supported by <see cref="M:string.Format"/>.
+    /// This also enables using {NamedformatItem} in the format string.
+    /// </summary>
+    public class FormattedLogValues : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        internal const int MaxCachedFormatters = 1024;
+        private const string NullFormat = "[null]";
+        private static int _count;
+        private static ConcurrentDictionary<string, LogValuesFormatter> _formatters = new ConcurrentDictionary<string, LogValuesFormatter>();
+        private readonly LogValuesFormatter _formatter;
+        private readonly object[] _values;
+        private readonly string _originalMessage;
+
+        // for testing purposes
+        internal LogValuesFormatter Formatter => _formatter;
+
+        public FormattedLogValues(string format, params object[] values)
+        {
+            if (values != null && values.Length != 0 && format != null)
+            {
+                if (_count >= MaxCachedFormatters)
+                {
+                    if (!_formatters.TryGetValue(format, out _formatter))
+                    {
+                        _formatter = new LogValuesFormatter(format);
+                    }
+                }
+                else
+                {
+                    _formatter = _formatters.GetOrAdd(format, f =>
+                    {
+                        Interlocked.Increment(ref _count);
+                        return new LogValuesFormatter(f);
+                    });
+                }
+            }
+            else
+            {
+                _formatter = null;
+            }
+
+            _originalMessage = format ?? NullFormat;
+            _values = values;
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                {
+                    throw new IndexOutOfRangeException(nameof(index));
+                }
+
+                if (index == Count - 1)
+                {
+                    return new KeyValuePair<string, object>("{OriginalFormat}", _originalMessage);
+                }
+
+                return _formatter.GetValue(_values, index);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (_formatter == null)
+                {
+                    return 1;
+                }
+
+                return _formatter.ValueNames.Count + 1;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            for (int i = 0; i < Count; ++i)
+            {
+                yield return this[i];
+            }
+        }
+
+        public override string ToString()
+        {
+            if (_formatter == null)
+            {
+                return _originalMessage;
+            }
+
+            return _formatter.Format(_values);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Logging/FormattedLogValuesExtensions.cs
+++ b/src/Logging/FormattedLogValuesExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging.Internal;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 
 namespace RedBear.LogDNA.Extensions.Logging

--- a/src/Logging/LogDNALogger.cs
+++ b/src/Logging/LogDNALogger.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Internal;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/Logging/LogValuesFormatter.cs
+++ b/src/Logging/LogValuesFormatter.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace RedBear.LogDNA.Extensions.Logging
+{
+    /// <summary>
+    /// Formatter to convert the named format items like {NamedformatItem} to <see cref="M:string.Format"/> format.
+    /// </summary>
+    public class LogValuesFormatter
+    {
+        private const string NullValue = "(null)";
+        private static readonly object[] EmptyArray = new object[0];
+        private static readonly char[] FormatDelimiters = { ',', ':' };
+        private readonly string _format;
+        private readonly List<string> _valueNames = new List<string>();
+
+        public LogValuesFormatter(string format)
+        {
+            OriginalFormat = format;
+
+            var sb = new StringBuilder();
+            var scanIndex = 0;
+            var endIndex = format.Length;
+
+            while (scanIndex < endIndex)
+            {
+                var openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
+
+                // Format item syntax : { index[,alignment][ :formatString] }.
+                var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
+
+                if (closeBraceIndex == endIndex)
+                {
+                    sb.Append(format, scanIndex, endIndex - scanIndex);
+                    scanIndex = endIndex;
+                }
+                else
+                {
+                    sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+                    sb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
+                    _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                    sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+
+                    scanIndex = closeBraceIndex + 1;
+                }
+            }
+
+            _format = sb.ToString();
+        }
+
+        public string OriginalFormat { get; private set; }
+        public List<string> ValueNames => _valueNames;
+
+        private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
+        {
+            // Example: {{prefix{{{Argument}}}suffix}}.
+            var braceIndex = endIndex;
+            var scanIndex = startIndex;
+            var braceOccurenceCount = 0;
+
+            while (scanIndex < endIndex)
+            {
+                if (braceOccurenceCount > 0 && format[scanIndex] != brace)
+                {
+                    if (braceOccurenceCount % 2 == 0)
+                    {
+                        // Even number of '{' or '}' found. Proceed search with next occurence of '{' or '}'.
+                        braceOccurenceCount = 0;
+                        braceIndex = endIndex;
+                    }
+                    else
+                    {
+                        // An unescaped '{' or '}' found.
+                        break;
+                    }
+                }
+                else if (format[scanIndex] == brace)
+                {
+                    if (brace == '}')
+                    {
+                        if (braceOccurenceCount == 0)
+                        {
+                            // For '}' pick the first occurence.
+                            braceIndex = scanIndex;
+                        }
+                    }
+                    else
+                    {
+                        // For '{' pick the last occurence.
+                        braceIndex = scanIndex;
+                    }
+
+                    braceOccurenceCount++;
+                }
+
+                scanIndex++;
+            }
+
+            return braceIndex;
+        }
+
+        private static int FindIndexOfAny(string format, char[] chars, int startIndex, int endIndex)
+        {
+            var findIndex = format.IndexOfAny(chars, startIndex, endIndex - startIndex);
+            return findIndex == -1 ? endIndex : findIndex;
+        }
+
+        public string Format(object[] values)
+        {
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    values[i] = FormatArgument(values[i]);
+                }
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, _format, values ?? EmptyArray);
+        }
+
+        internal string Format()
+        {
+            return _format;
+        }
+
+        internal string Format(object arg0)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0));
+        }
+
+        internal string Format(object arg0, object arg1)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1));
+        }
+
+        internal string Format(object arg0, object arg1, object arg2)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1), FormatArgument(arg2));
+        }
+
+        public KeyValuePair<string, object> GetValue(object[] values, int index)
+        {
+            if (index < 0 || index > _valueNames.Count)
+            {
+                throw new IndexOutOfRangeException(nameof(index));
+            }
+
+            if (_valueNames.Count > index)
+            {
+                return new KeyValuePair<string, object>(_valueNames[index], values[index]);
+            }
+
+            return new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetValues(object[] values)
+        {
+            var valueArray = new KeyValuePair<string, object>[values.Length + 1];
+            for (var index = 0; index != _valueNames.Count; ++index)
+            {
+                valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
+            }
+
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
+            return valueArray;
+        }
+
+        private object FormatArgument(object value)
+        {
+            if (value == null)
+            {
+                return NullValue;
+            }
+
+            // since 'string' implements IEnumerable, special case it
+            if (value is string)
+            {
+                return value;
+            }
+
+            // if the value implements IEnumerable, build a comma separated string.
+            var enumerable = value as IEnumerable;
+            if (enumerable != null)
+            {
+                return string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
+            }
+
+            return value;
+        }
+
+    }
+}

--- a/src/UnitTests/LogDNALoggerTests.cs
+++ b/src/UnitTests/LogDNALoggerTests.cs
@@ -5,7 +5,6 @@ using RedBear.LogDNA.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;


### PR DESCRIPTION
In netcore 3+ the FormattedLogValues and LogValuesFormatter are made internal and it's making the library to throw. These classes are taken from the Microsoft's repository and are replaced instead of using Microsoft.Extension.Logging.Internal. The library is working with the HttpApi and it is sending the logs to LogDNA.